### PR TITLE
Add PhpMyAdmin container to Docker #36

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,16 @@ services:
                 - '-p${DB_PASSWORD}'
             retries: 3
             timeout: 5s
+    phpmyadmin:
+        image: phpmyadmin
+        restart: always
+        ports:
+            - 8080:80
+        environment:
+            - PMA_ARBITRARY=1
+            - UPLOAD_LIMIT=300M
+        networks:
+            - sail
     redis:
         image: 'redis:alpine'
         ports:


### PR DESCRIPTION
Integrate PhpMyAdmin as a Docker container to facilitate database administration, enabling easy and efficient management of the database within the development environment.