### PR TITLE
Add rate limiting #25

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -11,11 +11,11 @@ Route::get('/user', function (Request $request) {
 })->middleware('auth:sanctum');
 
 Route::get('/events', [EventController::class, 'index'])->name('events.index');
-Route::apiResource('events', EventController::class)->middleware('auth:sanctum')->except('index');
+Route::apiResource('events', EventController::class)->middleware(['auth:sanctum', 'throttle:1'])->except('index');
 
 Route::post('/login', [AuthController::class, 'login']);
 Route::post('/logout', [AuthController::class, 'logout'])->middleware('auth:sanctum');
 
 Route::get('/events/{event}/participants', [ParticipantController::class, 'index'])->name('events.participants.index');
 Route::get('/events/{event}/participants/{participant}', [ParticipantController::class, 'index'])->name('events.participants.show');
-Route::apiResource('events.participants', ParticipantController::class)->except(['update'])->middleware('auth:sanctum')->except('index', 'show');
+Route::apiResource('events.participants', ParticipantController::class)->except(['update'])->middleware(['auth:sanctum', 'throttle:1'])->except('index', 'show');


### PR DESCRIPTION
Implement rate limiting measures for EventController and ParticipantController to throttle excessive requests and mitigate DDoS attacks, maintaining optimal performance under heavy traffic loads.